### PR TITLE
AFKR-6: Added document upload, appointment and bed management apps

### DIFF
--- a/configuration/openmrs/apps/home/extension.json
+++ b/configuration/openmrs/apps/home/extension.json
@@ -1,0 +1,53 @@
+{
+  "registration": {
+    "id": "bahmni.registration",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "translationKey": "MODULE_LABEL_REGISTRATION_KEY",
+    "url": "../registration/index.html",
+    "icon": "fa-user",
+    "order": 1,
+    "requiredPrivilege": "app:registration"
+  },
+  "clinical": {
+    "id": "bahmni.clinical",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "translationKey": "MODULE_LABEL_CLINICAL_KEY",
+    "url": "../clinical/index.html#/default/patient/search",
+    "icon": "fa-stethoscope",
+    "order": 3,
+    "requiredPrivilege": "app:clinical"
+  },
+  "patientDocumentUpload": {
+    "id": "bahmni.patient.document.upload",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "translationKey": "MODULE_LABEL_PATIENT_DOCUMENTS_KEY",
+    "url": "../document-upload/?encounterType=Patient Document&topLevelConcept=Patient Document&defaultOption=Patient file",
+    "icon": "icon-bahmni-documents",
+    "order": 4,
+    "requiredPrivilege": "app:patient-documents"
+  },
+  "bahmniIpd": {
+    "id": "bahmni.ipd",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "translationKey": "MODULE_LABEL_BED_MANAGEMENT_KEY",
+    "label": "InPatient",
+    "url": "../bedmanagement/#/home",
+    "icon": "fa-bed",
+    "order": 5,
+    "requiredPrivilege": "app:adt"
+  },
+  "appointmentScheduling": {
+    "id": "bahmni.appointment.scheduling",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "translationKey": "MODULE_LABEL_APPOINTMENT_SCHEDULING_KEY",
+    "url": "../appointments",
+    "icon": "fa fa-calendar",
+    "order": 14,
+    "requiredPrivilege": "app:appointments"
+  }
+}


### PR DESCRIPTION
@rbuisson To be able to see the appointment scheduling app, the user has to have the Appointments:FullAccess or Appointments:ManageAppointment
I think this is a bug in Bahmni, they should automatically be available for a user with superAdmin/System Developer role.
![Screenshot from 2020-02-17 13-24-54](https://user-images.githubusercontent.com/840071/74651265-15b9f080-518c-11ea-9b60-c8943191b909.png)
