### PR TITLE
AFKR-7: Adding configurations for admission and bed management app

### DIFF
--- a/configuration/openmrs/apps/clinical/app.json
+++ b/configuration/openmrs/apps/clinical/app.json
@@ -583,6 +583,11 @@
         "required": true,
         "disableAddNotes": true
       },
+      "adtNavigationConfig": {
+	"privilege": "app:adt",
+	"forwardUrl": "../bedmanagement/#/bedManagement/patient/{{patientUuid}}",
+	"title": "Go to IPD dashboard"
+      },
       "defaults": {}
     },
     "visitPage": {

--- a/configuration/openmrs/apps/clinical/app.json
+++ b/configuration/openmrs/apps/clinical/app.json
@@ -71,6 +71,11 @@
     "allowConsultationWhenNoOpenVisit": false,
     "maxConceptSetLevels": 3,
     "allowOnlyCodedDiagnosis": false,
+    "adtNavigationConfig": {
+      "privilege": "app:adt",
+      "forwardUrl": "../bedmanagement/#/bedManagement/patient/{{patientUuid}}",
+      "title": "Go to IPD dashboard"
+    },
     "conceptSetUI": {
       "Cambodia_Complaint Desc common": {
         "disableAddNotes": true,
@@ -582,11 +587,6 @@
       "Offline Diagnosis Certainty": {
         "required": true,
         "disableAddNotes": true
-      },
-      "adtNavigationConfig": {
-	"privilege": "app:adt",
-	"forwardUrl": "../bedmanagement/#/bedManagement/patient/{{patientUuid}}",
-	"title": "Go to IPD dashboard"
       },
       "defaults": {}
     },

--- a/configuration/openmrs/apps/clinical/extension.json
+++ b/configuration/openmrs/apps/clinical/extension.json
@@ -110,6 +110,17 @@
     "order": 2,
     "requiredPrivilege": "app:clinical:diagnosisTab"
 },
+  "disposition": {
+    "id": "bahmni.clinical.consultation.disposition",
+    "extensionPointId": "org.bahmni.clinical.consultation.board",
+    "type": "link",
+    "label": "Disposition",
+    "translationKey":"DISPOSITION_BOARD_LABEL_KEY",
+    "url": "disposition",
+    "icon": "fa-user-md",
+    "order": 3,
+    "requiredPrivilege": "app:clinical:dispositionTab"
+  },
 "bahmniClinicalConsultationOrders": {
   "id": "bahmni.clinical.consultation.orders",
   "extensionPointId": "org.bahmni.clinical.consultation.board",

--- a/configuration/openmrs/apps/ipd/app.json
+++ b/configuration/openmrs/apps/ipd/app.json
@@ -20,7 +20,7 @@
         "onAdmissionForwardTo": "#",
         "onTransferForwardTo": "#",
         "onDischargeForwardTo": "#",
-        "defaultVisitType": "IPD",
+        "defaultVisitType": "Hospitalisation",
         "expectedDateOfDischarge": "",
         "conceptSetUI": {
             "Expected Date of Discharge": {


### PR DESCRIPTION
- Added a disposition tab to the patient dashboard for requesting admissions

- The admission visit type for easydoc is "Hospitalisation", not IPD

- The bed icon from the consultation UI should forward to the bed management app, not the adt.