### PR TITLE
AFKR-12: Fix blood pressure report

### DIFF
--- a/configuration/openmrs/apps/reports/reports.json
+++ b/configuration/openmrs/apps/reports/reports.json
@@ -44,8 +44,8 @@
     "config": {
       "ageGroupName": "All Ages",
       "conceptNames": [
-        "Systolic",
-        "Diastolic"
+        "Haiti_Systolic Blood Pressure",
+        "Haiti_Diastolic Blood Pressure"
       ],
       "countOnlyClosedVisits": "false",
       "countOncePerPatient": "false"


### PR DESCRIPTION
What happened @rbuisson was the default diastolic and systolic pressure concepts were renamed by iniz to "Haiti_Systolic Blood Pressure" and "Haiti_Diastolic Blood Pressure".

I updated the report and it's showing values now.
![Screenshot from 2020-05-28 15-38-44](https://user-images.githubusercontent.com/840071/83148511-5913eb80-a0f9-11ea-8b7c-b99a099581d9.png)

