### PR TITLE
Add follow-up section and display control

### DIFF
--- a/configuration/openmrs/apps/clinical/dashboard.json
+++ b/configuration/openmrs/apps/clinical/dashboard.json
@@ -162,12 +162,12 @@
         "dashboardConfig": {},
         "numberOfVisits": 5
       },
-      "followup": {
+      "followUp": {
         "type": "forms",
         "isObservation": true,
         "displayOrder": 1001,
         "hideEmptyDisplayControl": false,
-        "dashBoardConfig": {
+        "dashboardConfig": {
           "showDetailsButton": true,
           "numberOfVisits": 5,
           "conceptNames": [

--- a/configuration/openmrs/apps/clinical/dashboard.json
+++ b/configuration/openmrs/apps/clinical/dashboard.json
@@ -169,7 +169,7 @@
         "hideEmptyDisplayControl": false,
         "dashboardConfig": {
           "showDetailsButton": true,
-          "numberOfVisits": 5,
+          "numberOfVisits": 2,
           "conceptNames": [
             "Follow Up Form"
           ]

--- a/configuration/openmrs/apps/clinical/dashboard.json
+++ b/configuration/openmrs/apps/clinical/dashboard.json
@@ -162,6 +162,17 @@
         "dashboardConfig": {},
         "numberOfVisits": 5
       },
+      "followup": {
+        "translationKey": "DASHBOARD_TITLE_FOLLOW_UP_KEY",
+        "type": "observation",
+        "title": "Follow up",
+        "isObservation": true,
+          "displayOrder":1001,
+          "dashboardConfig": {
+            "conceptNames": ["Medical treatment started", "Comments", "Home assistance requested"],
+              "scope": "latest"
+          }
+      },
       "radiologyOrders": {
         "orderType": "Radiology Order",
         "type": "ordersControl",
@@ -559,16 +570,5 @@
         "numberOfVisits": 5
       }
     }
-  },
-  "followup": {
-    "translationKey": "DASHBOARD_TITLE_FOLLOW_UP_KEY",
-    "type": "observation",
-    "title": "Follow up",
-    "isObservation": true,
-      "displayOrder":1001,
-      "dashboardConfig": {
-        "conceptNames": ["Medical treatment started", "Comments", "Home assistance requested"],
-          "scope": "latest"
-          }
-     }
+  }
 }

--- a/configuration/openmrs/apps/clinical/dashboard.json
+++ b/configuration/openmrs/apps/clinical/dashboard.json
@@ -559,5 +559,16 @@
         "numberOfVisits": 5
       }
     }
-  }
+  },
+  "followup": {
+    "translationKey": "DASHBOARD_TITLE_FOLLOW_UP_KEY",
+    "type": "observation",
+    "title": "Follow up",
+    "isObservation": true,
+      "displayOrder":1001,
+      "dashboardConfig": {
+        "conceptNames": ["Medical treatment started", "Comments", "Home assistance requested"],
+          "scope": "latest"
+          }
+     }
 }

--- a/configuration/openmrs/apps/clinical/dashboard.json
+++ b/configuration/openmrs/apps/clinical/dashboard.json
@@ -163,15 +163,26 @@
         "numberOfVisits": 5
       },
       "followup": {
-        "translationKey": "DASHBOARD_TITLE_FOLLOW_UP_KEY",
-        "type": "observation",
-        "title": "Follow up",
+        "type": "forms",
         "isObservation": true,
-          "displayOrder":1001,
-          "dashboardConfig": {
-            "conceptNames": ["Medical treatment started", "Comments", "Home assistance requested"],
-              "scope": "latest"
-          }
+        "displayOrder": 1001,
+        "hideEmptyDisplayControl": false,
+        "dashBoardConfig": {
+          "showDetailsButton": true,
+          "numberOfVisits": 5,
+          "conceptNames": [
+            "Follow Up Form"
+          ]
+        },
+        "expandedViewConfig": {
+          "showDetailsButton": true,
+          "showGroupDateTime": false,
+          "conceptNames": [
+            "Follow Up Form"
+          ],
+          "pivotTable": {}
+        },
+        "translationKey": "DASHBOARD_TITLE_FOLLOW_UP_KEY"
       },
       "radiologyOrders": {
         "orderType": "Radiology Order",

--- a/configuration/openmrs/apps/registration/extension.json
+++ b/configuration/openmrs/apps/registration/extension.json
@@ -67,6 +67,20 @@
         },
         "order": 1,
         "requiredPrivilege": "Edit Visits"
+    },
+    "followUp":{
+        "id": "bahmni.registration.conceptSetGroup.followUp",
+        "extensionPointId": "org.bahmni.registration.conceptSetGroup.observations",
+        "type": "config",
+        "extensionParams": {
+            "conceptName": "Follow Up Form",
+            "translationKey": "FOLLOW_UP",
+            "conceptNames": ["Medical treatment started","Home assistance requested"],
+            "required":true,
+            "showLatest": false
+        },
+        "order": 3,
+        "requiredPrivilege": "Edit Visits"
     }
 
 }

--- a/configuration/openmrs/i18n/clinical/locale_en.json
+++ b/configuration/openmrs/i18n/clinical/locale_en.json
@@ -122,6 +122,8 @@
   "IMPL_TESTS_IN_CLINIC_CHART":"Tests in Clinic",
   "CONSULTATION_PAD_EMPTY_MESSAGE":"No consultation Notes",
 
-  "CLINICAL_ACCEPT": "Accept"
+  "CLINICAL_ACCEPT": "Accept",
+
+  "DASHBOARD_TITLE_FOLLOW_UP_KEY": "Follow Up"
 
 }

--- a/configuration/openmrs/i18n/clinical/locale_fr.json
+++ b/configuration/openmrs/i18n/clinical/locale_fr.json
@@ -419,5 +419,8 @@
   "DASHBOARD_UPCOMING_APPOINTMENTS_KEY": "Prochains rendez-vous",
   "DASHBOARD_UPCOMING_APPOINTMENTS_KEY_LINK": "Vue en liste",
   "DASHBOARD_NO_PAST_APPOINTMENTS_KEY": "Aucun rendez-vous passé",
-  "DASHBOARD_NO_UPCOMING_APPOINTMENTS_KEY": "Aucun rendez-vous à venir"
+  "DASHBOARD_NO_UPCOMING_APPOINTMENTS_KEY": "Aucun rendez-vous à venir",
+
+  "DASHBOARD_TITLE_FOLLOW_UP_KEY": "Suivi Médical Téléphonique"
+
 }

--- a/configuration/openmrs/i18n/registration/locale_en.json
+++ b/configuration/openmrs/i18n/registration/locale_en.json
@@ -127,5 +127,6 @@
   "impl.commune": "Commune",
   "impl.district": "District",
   "impl.phoneNumber": "Phone Number",
-  "impl.province": "Province"
+  "impl.province": "Province",
+  "FOLLOW_UP": "Follow Up"
 }

--- a/configuration/openmrs/i18n/registration/locale_fr.json
+++ b/configuration/openmrs/i18n/registration/locale_fr.json
@@ -127,5 +127,6 @@
   "impl.commune": "Commune",
   "impl.district": "District",
   "impl.phoneNumber": "Numéro de téléphone",
-  "impl.province": "Province"
+  "impl.province": "Province",
+  "FOLLOW_UP": "Suivi Médical Téléphonique"
 }


### PR DESCRIPTION
Added the section on the second registration screen and `follow up` display widget under clinical with the corresponding English and French translations. 